### PR TITLE
Fixed project_tree, now only looking inside src/

### DIFF
--- a/src/canari/commands/common.py
+++ b/src/canari/commands/common.py
@@ -180,16 +180,15 @@ def project_tree():
 
     tree = dict(
         root=root,
-        src=None,
+        # src is always directly under root
+        src=os.path.join(root, 'src'),
         pkg=None,
         resources=None,
         transforms=None
     )
 
-    for base, dirs, files in os.walk(root):
-        if base.endswith('src'):
-            tree['src'] = base
-        elif 'resources' in dirs:
+    for base, dirs, files in os.walk(tree['src']):
+        if 'resources' in dirs:
             tree['pkg'] = base
         elif base.endswith('resources'):
             tree['resources'] = base


### PR DESCRIPTION
If the project root folder contains for example a build/ or a dist/
folder, which may contain some of the sub folders which project_tree is
looking for, then the result may not bee the expected.

This error is fixed by forcing project_tree to search for sub folders
inside the src/ folder only.
