### PR TITLE
Fixed canari list-transforms

### DIFF
--- a/src/canari/commands/list_transforms.py
+++ b/src/canari/commands/list_transforms.py
@@ -4,7 +4,7 @@ import os
 from canari.maltego.utils import highlight
 from canari.pkgutils.transform import TransformDistribution
 
-from common import (canari_main, uproot, pushd)
+from common import (canari_main, uproot, pushd, project_tree)
 from framework import SubCommand, Argument
 
 
@@ -21,45 +21,68 @@ __status__ = 'Development'
 
 # Extra sauce to parse args
 def parse_args(args):
+    try:
+        ptree = project_tree()
+    except Exception as ex:
+        print "Got exception while trying to determine the project root. " \
+              "Supply a proper --src-dir argument."
+        print 'Exception:', highlight(str(ex), 'red', False)
+        exit(-1)
+
+    if args.src_dir is None:
+        args.src_dir = ptree['src']
+    if args.package is None:
+        _, args.package = ptree['pkg'].rsplit(os.path.sep, 1)
+
     return args
 
 
 # Argument parser
 @SubCommand(
     canari_main,
-    help="Installs and configures canari transform packages in Maltego's UI",
-    description="Installs and configures canari transform packages in Maltego's UI"
+    help="List transforms inside the given transform package.",
+    description="List transforms inside the given transform package."
 )
 @Argument(
     'package',
     metavar='<package>',
-    help='the name of the canari transforms package to install.'
+    nargs='?',
+    default=None,
+    help="the name of the canari transform package to list transforms from. "
+         "Python 'import' ordering is used, thus a specified working directory "
+         "will supersede any installed packages. If not specified, the package "
+         "name will be read from the project configuration if --src-dir or the "
+         "current working directory is a valid transform package."
 )
 @Argument(
-    '-w',
-    '--working-dir',
-    metavar='[working dir]',
+    '-d',
+    '--src-dir',
+    metavar='[src dir]',
     default=None,
-    help="the path that will be used as the working directory for "
-         "the transforms being installed (default: ~/.canari/)"
+    help="the path that will be used when looking for the transform package "
+         "(<package>). Should point to the source folder (src) containing the "
+         "specified transform package. If not specified, it will try and guess "
+         "the src folder or use the current working directory as a fall back."
 )
 def list_transforms(args):
 
     opts = parse_args(args)
 
     try:
-        with pushd(opts.working_dir or os.getcwd()):
+        with pushd(opts.src_dir or os.getcwd()):
             transform_package = TransformDistribution(opts.package)
             for t in transform_package.transforms:
-                print ('`- %s: %s' % (highlight(t.__name__, 'green', True), t.dotransform.description))
+                print ('`- %s: %s' % (highlight(t.__name__, 'green', True),
+                                      t.dotransform.description))
                 print (highlight('  `- Maltego identifiers:', 'black', True))
-                for uuid, (input_set, input_type) in zip(t.dotransform.uuids, t.dotransform.inputs):
+                for uuid, (input_set, input_type) in zip(t.dotransform.uuids,
+                                                         t.dotransform.inputs):
                     print '    `- %s applies to %s in set %s' % (
                         highlight(uuid, 'red', False),
                         highlight(input_type._type_, 'red', False),
                         highlight(input_set, 'red', False)
                     )
                 print ''
-    except ValueError, e:
+    except ValueError as e:
         print str(e)
         exit(-1)


### PR DESCRIPTION
Fixes:
- Now has the correct help messages, and not the copy/paste from the
  install-package command.
- Now has a -d/--src-dir argument instead of the copy/paste
  --working-dir from the install-package command.
- Will now try and guess the --src-dir argument if not specified, just
  as the create-transform command will try and guess the transform
  directory by using information from project_tree().
- Will now infer the package name if it is not specified, and if a
  valid --src-dir or current working directory is used. Valid being a
  transform package directory such that project_tree() will return
  useful information.
