### PR TITLE
made TransformDistribution fail gracefully

### DIFF
--- a/src/canari/pkgutils/transform.py
+++ b/src/canari/pkgutils/transform.py
@@ -29,8 +29,13 @@ __all__ = [
 class TransformDistribution(object):
 
     def __init__(self, package_name):
-        self._package_name = package_name.replace('.transforms', '') \
-            if package_name.endswith('.transforms') else package_name
+        try:
+            self._package_name = package_name.replace('.transforms', '') \
+                                 if package_name.endswith('.transforms') else package_name
+        except AttributeError:
+            # Correct way of handling python duck typing. Above will work for
+            # both str and unicode strings.
+            raise TypeError("'package_name' should be a string.")
 
         print('Looking for transforms in %s.transforms...' % self.name)
         try:


### PR DESCRIPTION
When trying to make a TransformDistribution from something other
than a string (e.g., the actual module), it will fail as it tries
to do string operations on the argument.  Now it will raise an
TypeError with a better description.

We don't use isinstance(..., str) as that would not handle a
unicode string, or any other (duck) type that would potentially fit.