### PR TITLE
Fix/list transforms

### DIFF
--- a/src/canari/commands/list_commands.py
+++ b/src/canari/commands/list_commands.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 
 from common import canari_main
-from canari.maltego.utils import highlight
+from canari.utils.console import highlight
 from framework import SubCommand
 
 __author__ = 'Nadeem Douba'

--- a/src/canari/commands/list_transforms.py
+++ b/src/canari/commands/list_transforms.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 
 import os
-from canari.maltego.utils import highlight
+from canari.utils.console import highlight
 from canari.pkgutils.transform import TransformDistribution
 
 from common import (canari_main, uproot, pushd)

--- a/src/canari/commands/list_transforms.py
+++ b/src/canari/commands/list_transforms.py
@@ -4,13 +4,13 @@ import os
 from canari.utils.console import highlight
 from canari.pkgutils.transform import TransformDistribution
 
-from common import (canari_main, uproot, pushd)
+from common import (canari_main, pushd, project_tree)
 from framework import SubCommand, Argument
 
 
 __author__ = 'Nadeem Douba'
 __copyright__ = 'Copyright 2012, Canari Project'
-__credits__ = []
+__credits__ = ['Jesper Reenberg']
 
 __license__ = 'GPL'
 __version__ = '0.6'
@@ -19,36 +19,77 @@ __email__ = 'ndouba@gmail.com'
 __status__ = 'Development'
 
 
-# Extra sauce to parse args
 def parse_args(args):
+    args.ptree = project_tree(package = args.package)
+    args.package = args.ptree['pkg_name']
+    # We specifically don't update 'args' with any of the info from ptree.  This
+    # way we always know exactly what information was specified by the user.
     return args
-
 
 # Argument parser
 @SubCommand(
     canari_main,
-    help="Installs and configures canari transform packages in Maltego's UI",
-    description="Installs and configures canari transform packages in Maltego's UI"
+    help="List transforms inside the given transform package",
+    description="List transforms inside a given transform package (<package>).  "
+        "Python 'import' ordering is used, thus a specified directory (--dir) "
+        "will supersede the current working directory which superseeds installed "
+        "packages, as long as a canari project is found in any of the two.  If "
+        "no package name is specified, then all possible transform packages "
+        "inside the found canari project is listed."
 )
 @Argument(
     'package',
     metavar='<package>',
-    help='the name of the canari transforms package to install.'
+    nargs='?',
+    default=None,
+    help="the name of the canari transform package to list transforms from.  If"
+        "no canari project is located, then the installed modules is searched."
 )
 @Argument(
-    '-w',
-    '--working-dir',
-    metavar='[working dir]',
-    default=None,
-    help="the path that will be used as the working directory for "
-         "the transforms being installed (default: ~/.canari/)"
+    '-d',
+    '--dir',
+    metavar='[dir]',
+    default=os.getcwd(),
+    help="if supplied, the path will owerwrite the current working directory when "
+         "searching for canari projects."
 )
+
+
 def list_transforms(args):
 
-    opts = parse_args(args)
+    # TODO: project_tree may raise an exception if either project_root can't be
+    # determined or if we can't find the package as an installed package.
+    # Atleast the create-transform command calls this function without handling
+    # the possible exception.  What is the best sollution?
+
+    # TODO: create-transform takes an argument --transform-dir which can be used
+    # to control where to place the transform template. This breaks the new
+    # assumption of the 'transforms' folder always being inside the 'pkg'
+    # folder.  However this is an assumption all over the place, so this
+    # parameter doesn't really make much sense?
+
+    # TODO: There are most likely many commands with similar problems
+    # (above). and perhaps they should be updated to use the below template and
+    # have their argument updated to -d/--dir instead with CWD as the default
+    # value.
+
+    # TODO: Perhaps we should introduce a 'create' command that will just make
+    # an empty canari root dir (project). Inside this we can then call
+    # create-package a number of times to generate all the desired
+    # packages. This could even be automated for N-times during the call to
+    # 'create'. 'create-package' can even still default to call 'create' if not
+    # inside a canari root directory, to preserve backwards compatability.
+
+    # TODO: Handle hyphening of package names. When creating them and when
+    # trying to access them.  This goes for project_tree, it should change '-'
+    # with '_' in the package name.
 
     try:
-        with pushd(opts.working_dir or os.getcwd()):
+        with pushd(args.dir):
+            opts = parse_args(args)
+
+        with pushd(args.ptree['src']):
+
             transform_package = TransformDistribution(opts.package)
             for t in transform_package.transforms:
                 print ('`- %s: %s' % (highlight(t.__name__, 'green', True), t.dotransform.description))

--- a/src/canari/commands/shell.py
+++ b/src/canari/commands/shell.py
@@ -9,7 +9,8 @@ from canari.pkgutils.transform import TransformDistribution
 from common import canari_main, fix_pypath, fix_binpath, import_package, pushd
 from framework import SubCommand, Argument
 from canari.config import config
-from canari.maltego.utils import highlight, console_message, local_transform_runner
+from canari.maltego.utils import console_message, local_transform_runner
+from canari.utils.console import highlight
 import canari
 
 

--- a/src/canari/maltego/utils.py
+++ b/src/canari/maltego/utils.py
@@ -11,6 +11,7 @@ from safedexml import Model
 
 from canari.commands.common import sudo, import_transform
 from canari.maltego.entities import Unknown
+from canari.utils.console import highlight
 from message import MaltegoMessage, MaltegoTransformExceptionMessage, MaltegoException, \
     MaltegoTransformResponseMessage, MaltegoTransformRequestMessage, UIMessage, Field
 
@@ -27,7 +28,6 @@ __status__ = 'Development'
 __all__ = [
     'onterminate',
     'message',
-    'highlight',
     'console_message',
     'croak',
     'guess_entity_type',
@@ -49,28 +49,6 @@ def message(m, fd=sys.stdout):
     """Write a MaltegoMessage to stdout and exit successfully"""
     print MaltegoMessage(message=m).render(fragment=True)
     sys.exit(0)
-
-
-def highlight(s, color, bold):
-    """
-    Internal API: Returns the colorized version of the text to be returned to a POSIX terminal. Not compatible with
-    Windows (yet).
-    """
-    if os.name == 'posix':
-        attr = []
-        if color == 'green':
-            # green
-            attr.append('32')
-        elif color == 'red':
-            # red
-            attr.append('31')
-        else:
-            attr.append('30')
-        if bold:
-            attr.append('1')
-        s = '\x1b[%sm%s\x1b[0m' % (';'.join(attr), s)
-
-    return s
 
 
 def console_message(msg, tab=-1):

--- a/src/canari/utils/console.py
+++ b/src/canari/utils/console.py
@@ -1,0 +1,39 @@
+#!/usr/bin/env python
+
+import os
+
+__author__ = 'Nadeem Douba'
+__copyright__ = 'Copyright 2012, Canari Project'
+__credits__ = []
+
+__license__ = 'GPL'
+__version__ = '0.1'
+__maintainer__ = 'Nadeem Douba'
+__email__ = 'ndouba@gmail.com'
+__status__ = 'Development'
+
+__all__ = [
+    'highlight',
+]
+
+
+def highlight(s, color, bold):
+    """
+    Internal API: Returns the colorized version of the text to be returned to a POSIX terminal. Not compatible with
+    Windows (yet).
+    """
+    if os.name == 'posix':
+        attr = []
+        if color == 'green':
+            # green
+            attr.append('32')
+        elif color == 'red':
+            # red
+            attr.append('31')
+        else:
+            attr.append('30')
+        if bold:
+            attr.append('1')
+        s = '\x1b[%sm%s\x1b[0m' % (';'.join(attr), s)
+
+    return s


### PR DESCRIPTION
Now it should work, in and out of a canari project directory, as well as with the name of an installed package..
I have added some more logic code into the project_tree which adds support for multiple transform packages inside a canari project, which I could see usefull in the future. 
99% of the time this addition should not bee visible to the user, unless she didn't write a package name on the command line and the src folder contains multiple other folders, that might look like a transforms package. (aka wery unlikely)
