### PR TITLE
Fix stupid defaults in safedexml.

### DIFF
--- a/src/canari/xmltools/oxml.py
+++ b/src/canari/xmltools/oxml.py
@@ -20,6 +20,12 @@ __all__ = [
 
 class MaltegoElement(Model):
 
+    class meta:
+        # Fix stupid defaults in safedexml. We are dealing with ordinarry XML so
+        # threat it that way
+        order_sensitive = False
+
+
     def __add__(self, other):
         return self.__iadd__(other)
 


### PR DESCRIPTION
We are dealing with ordinarry XML so threat it that way.

It was impossible to parse the following valid XML from Maltego, without
this fix, as it required the elements to be ordered according to how
they were defined in the c.m.m._Entity class.

---------------------------------------------------------------------------
```python
import canari.maltego.message as msg

msg._Entity.parse('''
<Entity Type="Domain">
  <AdditionalFields>
    <Field Name="fqdn" DisplayName="Domain Name">paterva.com</Field>
  </AdditionalFields>
  <Weight>66</Weight>
  <Value>paterva.com</Value>
</Entity>
''')
```
---------------------------------------------------------------------------
```python
ParseError    Traceback (most recent call last)
<ipython-input-2-abb8246f3cd9> in <module>()
      7             <Value>paterva.com</Value>
      8          </Entity>
----> 9 ''')

/usr/local/lib/python2.7/dist-packages/safedexml/__init__.py in
parse(cls, xml)
    351             if field.required and field not in fields_found:
    352                 err = "required field not found: '%s'"
    % (field.field_name,)
--> 353                 raise ParseError(err)
    354             field.parse_done(self)
    355         #  All done, return the instance so created

ParseError: required field not found: 'value'
```