### PR TITLE
Make str codepath in config handle unicode as well

### DIFF
--- a/src/canari/config.py
+++ b/src/canari/config.py
@@ -27,7 +27,7 @@ __all__ = [
 
 class CanariConfigParser(SafeConfigParser):
     def _interpolate_environment_variables(self, value):
-        if isinstance(value, str):
+        if isinstance(value, basestring):
             evs = self._get_env_vars(value)
             if evs:
                 for ev in evs:
@@ -36,7 +36,7 @@ class CanariConfigParser(SafeConfigParser):
         return value
 
     def _interpolate(self, section, option, value, d):
-        if isinstance(value, str):
+        if isinstance(value, basestring):
             value = self._interpolate_environment_variables(value)
         elif isinstance(value, dict):
             for i in value:


### PR DESCRIPTION
Trying to run transforms remote i get an error like `TypeError: 'unicode' object does not support item assignment`. This seem to solve that, but my understanding of the code base in general is very limited so not sure what other effects there are or if there where any intent behind limiting to str.