### PR TITLE
Remote exception code

### DIFF
--- a/src/canari/maltego/message.py
+++ b/src/canari/maltego/message.py
@@ -51,10 +51,11 @@ class MaltegoException(MaltegoElement, Exception):
     class meta:
         tagname = 'Exception'
 
-    def __init__(self, value):
-        super(MaltegoException, self).__init__(value=value),
+    def __init__(self, value, code=None):
+        super(MaltegoException, self).__init__(value=value, code=code),
 
     value = fields_.String(tagname='.')
+    code = fields_.String(required=False)
 
 
 class MaltegoTransformExceptionMessage(MaltegoElement):


### PR DESCRIPTION
I couldn't figure out a way to make plume return a 600 coded maltego exception as mentioned in http://dev.paterva.com/developer/advanced/transform_hub.php. I tried to use croak for this, but unsuccessfully. The following changes should allow you to customize a return exception in the transform.