### PR TITLE
Fix Windows installs with Python 2.7 not located in the PATH variable

### DIFF
--- a/src/scripts/canari.bat
+++ b/src/scripts/canari.bat
@@ -1,1 +1,7 @@
-@python %~dp0\canari %*
+@echo off
+
+IF EXIST %~dp0\..\python.exe (
+    %~dp0\..\python.exe %~dp0\canari %*
+) else (
+    @python %~dp0\canari %*
+)

--- a/src/scripts/dispatcher.bat
+++ b/src/scripts/dispatcher.bat
@@ -1,1 +1,7 @@
-@python %~dp0\dispatcher %*
+@echo off
+
+IF EXIST %~dp0\..\python.exe (
+    %~dp0\..\python.exe %~dp0\dispatcher %*
+) else (
+    @python %~dp0\dispatcher %*
+)

--- a/src/scripts/pysudo.bat
+++ b/src/scripts/pysudo.bat
@@ -1,1 +1,7 @@
-@python %~dp0\pysudo %*
+@echo off
+
+IF EXIST %~dp0\..\python.exe (
+    %~dp0\..\python.exe %~dp0\pysudo %*
+) else (
+    @python %~dp0\pysudo %*
+)


### PR DESCRIPTION
The fix addresses the situation where Python 2.7 is not located in the Windows `PATH` environmental variable. In my situation I have Python 3.3 located in `PATH` and, therefore, Maltego transforms fail to execute stating that the `canari` package is not installed.

The fix works by first checking if the script's parent directory contains the `python.exe` executable and, if it does, uses this executable rather than the one located in `PATH`.

For Windows installations, the Python directory structure is:

```
<root install> (C:\Python) \
    Python.exe
    Scripts\
        dispatcher.bat
        canari.bat
```

This way, `canari.bat` will check if `<root install>\Python.exe` exists, and if it does, execute that version of Python. If this executable doesn't exist, the Python version located in the `PATH` is executed.